### PR TITLE
added plan to Subscription page

### DIFF
--- a/src/Components/Account/components/Security/Security.js
+++ b/src/Components/Account/components/Security/Security.js
@@ -27,6 +27,13 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center"
+  },
+  planText: {
+    color: "#3f51b5",
+    border: "1px solid rgba(63, 81, 181, 0.5)",
+    padding: "0.25em",
+    borderRadius: "4px",
+    textTransform: "uppercase"
   }
 }));
 
@@ -39,12 +46,20 @@ const Security = props => {
     defaultMatches: true
   });
   const userTier = useSelector(state => state.tierReducer.tier);
-  const showPlan = () => {
+  const getPlan = () => {
     let plan = userTier;
+    switch (plan) {
+      case "FREE":
+        plan = "Free Trial";
+        break;
+      case "PAID":
+        plan = "Premium Access";
+        break;
+    }
     if (typeof plan !== "string") {
       plan = "Please log out and login again to see your plan.";
     }
-    return `Your Plan: ${plan}`;
+    return plan;
   };
 
   return (
@@ -53,7 +68,8 @@ const Security = props => {
         <Grid item xs={12}>
           <div className={classes.titleCta}>
             <Typography variant="h6" color="textPrimary">
-              {showPlan()}
+              <span>{"Your Plan: "}</span>
+              <span className={classes.planText}> {getPlan()} </span>
             </Typography>
           </div>
         </Grid>

--- a/src/Components/Account/components/Security/Security.js
+++ b/src/Components/Account/components/Security/Security.js
@@ -6,15 +6,13 @@ import {
   useMediaQuery,
   Grid,
   Typography,
-  TextField,
-  FormControlLabel,
-  Switch,
   Button,
   Divider,
   colors
 } from "@material-ui/core";
 import Icon from "../../../themeStyledComponents/atoms/Icon/";
 import CardPricingStandard from "../../../themeStyledComponents/organisms/CardPricingStandard";
+import { useSelector } from "react-redux";
 
 const useStyles = makeStyles(theme => ({
   root: {},
@@ -40,6 +38,14 @@ const Security = props => {
   const isMd = useMediaQuery(theme.breakpoints.up("md"), {
     defaultMatches: true
   });
+  const userTier = useSelector(state => state.tierReducer.tier);
+  const showPlan = () => {
+    let plan = userTier;
+    if (typeof plan !== "string") {
+      plan = "Please log out and login again to see your plan.";
+    }
+    return `Your Plan: ${plan}`;
+  };
 
   return (
     <div className={clsx(classes.root, className)} {...rest}>
@@ -47,7 +53,7 @@ const Security = props => {
         <Grid item xs={12}>
           <div className={classes.titleCta}>
             <Typography variant="h6" color="textPrimary">
-              Your Plan: [PLAN NAME HERE]
+              {showPlan()}
             </Typography>
           </div>
         </Grid>


### PR DESCRIPTION

trello [https://trello.com/c/ghcGfiMs/22-plan-name-on-myaccount-subscriptions-page](url)

Account page to reflect on subscription page.

*** I think only on local host, when we make changes and rerender, there is a possiblity account plan variable would not be available.  So, I put a notice : "Please log out and login again to see your plan."   But I am not sure this would happen in production.